### PR TITLE
fix(test/decorators): fix event delegation test

### DIFF
--- a/test/decorators.js
+++ b/test/decorators.js
@@ -56,8 +56,12 @@ describe('@on(event, {at: selector})', () => {
 
     const elem = div(div({addClass: 'inner'})).cc('on-at-test0')
 
+    document.body.appendChild(elem[0])
+
     elem[0].dispatchEvent(new CustomEvent('bar-event', {bubbles: true}))
     elem.find('.inner')[0].dispatchEvent(new CustomEvent('foo-event', {bubbles: true}))
+
+    document.body.removeChild(elem[0])
   })
 })
 


### PR DESCRIPTION
In chrome 55, event bubbles in detached dom tree, but in chrome 43
(circleci's default), it doesn't.
This fixes the test failure in circle ci.