### PR TITLE
chore: fix error on ci env (because of old chrome version)

### DIFF
--- a/test/decorators.js
+++ b/test/decorators.js
@@ -95,9 +95,11 @@ describe('@emit(event)', () => {
     $.cc('emit-test1', EmitTest1)
     callDecorator(emit('event-foo'), EmitTest1, 'foo')
 
-    const parent = div().on('event-foo', () => done())
+    const parent = div().on('event-foo', () => done()).appendTo('body')
 
     div().appendTo(parent).cc.init('emit-test1').foo()
+
+    parent.remove()
   })
 })
 


### PR DESCRIPTION
In old chrome version, event doesn't bubbles in a detached tree.